### PR TITLE
Fix a bug where body would retain the 'coveo-modalBox-opened' class

### DIFF
--- a/src/ModalBox.ts
+++ b/src/ModalBox.ts
@@ -134,7 +134,7 @@ module Coveo.ModalBox {
         if (index >= 0) {
           closeFunctions.splice(index, 1);
         }
-        if (body.querySelector('.coveo-modalBox') != undefined) {
+        if (body.querySelector('.coveo-modalBox') == null) {
           removeClassName(body, 'coveo-modalBox-opened');
         }
         return true;


### PR DESCRIPTION
querySelector returns `null`, and we want to remove the `coveo-modalBox-opened` class if the modal box was closed instead of the inverse.
